### PR TITLE
Connect Earn Page to database

### DIFF
--- a/src/pages/resident.html
+++ b/src/pages/resident.html
@@ -7,6 +7,12 @@
             "width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/src/styles/resident.css">
     <title>Resident Page</title>
+    <script type="module">
+        import { changeContent } from '/src/scripts/resident.js';
+    
+        // Attach it to the global `window` object if needed
+        window.changeContent = changeContent;
+    </script>
 </head>
 
 <body>
@@ -51,7 +57,6 @@
         </div>
     </main>
 </div>
-<script src="/src/scripts/resident.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Currently, `earn` page is connected to the database. 

A few more modifications are required from here: 
 - [x] When the `Accept` button is pressed, redirect users to the `account` page. 
 - [ ] When the `Accept` button is pressed, when trying to accept other task, alert would show "Complete your current task before proceeding to another task!" 
 - [ ] When the `Accept` button is pressed, modification should be made to the person's account ( have an account database for residents and admins )
 - [x] Modifying the data being passed around in `resident.js`: Currently, only taskId is passed around, but for the alert, task description is required (which can be attained from task.description if I am not wrong)
